### PR TITLE
Fix all occurrences of missing the client object for get() calls

### DIFF
--- a/fast_arrow/resources/option_event.py
+++ b/fast_arrow/resources/option_event.py
@@ -14,7 +14,7 @@ class OptionEvent(object):
         data = client.get(url, params=params)
         results = data["results"]
         while data["next"]:
-            data = get(data["next"], token)
+            data = client.get(data["next"], token)
             results.extend(data["results"])
         return results
 

--- a/fast_arrow/resources/option_marketdata.py
+++ b/fast_arrow/resources/option_marketdata.py
@@ -30,7 +30,7 @@ class OptionMarketdata(object):
             if data and "results" in data:
                 partial_results = data["results"]
                 while ("next" in data and data["next"]):
-                    data = get(data["next"], bearer=bearer)
+                    data = client.get(data["next"], bearer=bearer)
                     partial_results.extend(data["results"])
                 results.extend(partial_results)
         return results

--- a/fast_arrow/resources/option_position.py
+++ b/fast_arrow/resources/option_position.py
@@ -16,7 +16,7 @@ class OptionPosition(object):
         data = client.get(url, params=params)
         results = data["results"]
         while data["next"]:
-            data = get(data["next"], token)
+            data = client.get(data["next"], token)
             results.extend(data["results"])
         return results
 

--- a/fast_arrow/resources/position.py
+++ b/fast_arrow/resources/position.py
@@ -11,6 +11,6 @@ class Position(object):
         data = clientget(url)
         positions.extend(data["results"])
         while data["next"]:
-            data = get(data["next"], token)
+            data = client.get(data["next"], token)
             positions.extend(data["results"])
         return positions

--- a/fast_arrow/resources/stock.py
+++ b/fast_arrow/resources/stock.py
@@ -48,6 +48,6 @@ class Stock(object):
         results = data["results"]
 
         while data["next"]:
-            data = get(data["next"], bearer=bearer)
+            data = client.get(data["next"], bearer=bearer)
             results.extend(data["results"])
         return results

--- a/fast_arrow/resources/stock_marketdata.py
+++ b/fast_arrow/resources/stock_marketdata.py
@@ -55,6 +55,6 @@ class StockMarketdata(object):
         data = client.get(url, params=params)
         results = data["results"]
         while "next" in data and data["next"]:
-            data = get(data["next"], bearer=bearer)
+            data = client.get(data["next"], bearer=bearer)
             results.extend(data["results"])
         return results

--- a/fast_arrow/resources/stock_order.py
+++ b/fast_arrow/resources/stock_order.py
@@ -10,6 +10,6 @@ class StockOrder(object):
         data = client.get(url)
         results = data["results"]
         while data["next"]:
-            data = get(data["next"], token=token)
+            data = client.get(data["next"], token=token)
             results.extend(data["results"])
         return results


### PR DESCRIPTION
This PR replaces all occurrences of get(...) with client.get(...) in the resources folder.

Addresses #43 