### PR TITLE
Fix 400 error on mfa authentication

### DIFF
--- a/fast_arrow/client.py
+++ b/fast_arrow/client.py
@@ -1,4 +1,6 @@
 import os
+import uuid
+
 import requests
 from fast_arrow.util import get_last_path
 from fast_arrow.resources.account import Account
@@ -111,6 +113,7 @@ class Client(object):
         Login using username and password
         '''
         data = {
+            "device_token": uuid.uuid4(),
             "grant_type": "password",
             "scope": "internal",
             "client_id": CLIENT_ID,


### PR DESCRIPTION
The web API uses `device_token` as one of the fields during authentication. Looking at the issues for this and other similar API clients, people have been generating these randomly but it can also be done by the standard `uuid` library.

Without this change, I get this error calling `Client.authenticate()`:
```requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.robinhood.com/oauth2/token/```

